### PR TITLE
This should add the ability for the client to get the user creds from the global git config

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -10,7 +10,7 @@ You have three ways of defining your user to have authenticated access to your A
         login: your_login
         token: your_token
   2. Put GITHUB_USER and GITHUB_TOKEN in your environment, so github-api-client can read it.
-  3. Configure you global git profile as defined here http://help.github.com/git-email-settings/
+  3. Configure you global git profile as defined here [http://help.github.com/git-email-settings](http://help.github.com/git-email-settings)
 
 == Contributing to github-api-client
  

--- a/README.rdoc
+++ b/README.rdoc
@@ -10,8 +10,8 @@ You have three ways of defining your user to have authenticated access to your A
         login: your_login
         token: your_token
   2. Put GITHUB_USER and GITHUB_TOKEN in your environment, so github-api-client can read it.
-  3. Configure you global git profile as defined here [http://help.github.com/git-email-settings](http://help.github.com/git-email-settings)
-
+  3. Configure your global git profile as defined here http://help.github.com/git-email-settings
+  
 == Contributing to github-api-client
  
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,6 +2,16 @@
 
 Description goes here.
 
+= Configuration
+You have three ways of defining your user to have authenticated access to your API:
+  1. Put a file in: /Users/parker/.github/secrets.yml
+    Define in yaml:
+      user:
+        login: your_login
+        token: your_token
+  2. Put GITHUB_USER and GITHUB_TOKEN in your environment, so github-api-client can read it.
+  3. Configure you global git profile as defined here http://help.github.com/git-email-settings/
+
 == Contributing to github-api-client
  
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet

--- a/lib/github-api-client/config.rb
+++ b/lib/github-api-client/config.rb
@@ -20,11 +20,11 @@ module GitHub
       "token" => ENV['GITHUB_TOKEN']
     } if ENV['GITHUB_USER'] && ENV['GITHUB_TOKEN']
     
-   # Secrets ||= {
-   #   "login" => `git config --global github.user`.strip, 
-   #   "token" => `git config --global github.token`.strip
-   # } if !`git config --global github.user`.empty? && !`git config --global github.token`.empty?
-    
+    Secrets ||= {
+      "login" => `git config --global github.user`.strip, 
+      "token" => `git config --global github.token`.strip
+    } if `git config --global github.user` && !`git config --global github.token`
+   
     begin
       # If not env vars, then ~/.github/secrets.yml
       Secrets ||= YAML::load_file(GitHub::Config::Path[:secrets])['user']

--- a/lib/github-api-client/config.rb
+++ b/lib/github-api-client/config.rb
@@ -38,7 +38,7 @@ You have three ways of defining your user to have authenticated access to your A
         #{"login".color(:green).bright}: #{"your_login".color(:magenta)}
         #{"token".color(:blue).bright}: #{"your_token".color(:magenta)}
   #{"2.".color(:cyan)} Put #{"GITHUB_USER".color(:green).bright} and #{"GITHUB_TOKEN".color(:blue).bright} in your environment, so github-api-client can read it.
-  #{"3.".color(:cyan)} Configure you global git profile as defined here #{"http://help.github.com/git-email-settings/".color(:blue).bright}
+  #{"3.".color(:cyan)} Configure your global git profile as defined here #{"http://help.github.com/git-email-settings/".color(:blue).bright}
   
       report
     end

--- a/lib/github-api-client/config.rb
+++ b/lib/github-api-client/config.rb
@@ -31,13 +31,14 @@ module GitHub
     rescue Errno::ENOENT
       # Eye candy with rainbow
       puts <<-report
-You have two ways of defining your user to have authenticated access to your API:
+You have three ways of defining your user to have authenticated access to your API:
   #{"1.".color(:cyan)} Put a file in: #{GitHub::Config::Path[:secrets].color(:blue).bright}
     Define in yaml:
       #{"user".color(:yellow).bright}:
         #{"login".color(:green).bright}: #{"your_login".color(:magenta)}
         #{"token".color(:blue).bright}: #{"your_token".color(:magenta)}
   #{"2.".color(:cyan)} Put #{"GITHUB_USER".color(:green).bright} and #{"GITHUB_TOKEN".color(:blue).bright} in your environment, so github-api-client can read it.
+  #{"3.".color(:cyan)} Configure you global git profile as defined here #{"http://help.github.com/git-email-settings/".color(:blue).bright}
   
       report
     end

--- a/lib/github-api-client/config.rb
+++ b/lib/github-api-client/config.rb
@@ -20,10 +20,10 @@ module GitHub
       "token" => ENV['GITHUB_TOKEN']
     } if ENV['GITHUB_USER'] && ENV['GITHUB_TOKEN']
     
-    Secrets ||= {
-      "login" => `git config --global github.user`.strip, 
-      "token" => `git config --global github.token`.strip
-    } if `git config --global github.user` && `git config --global github.token`
+   # Secrets ||= {
+   #   "login" => `git config --global github.user`.strip, 
+   #   "token" => `git config --global github.token`.strip
+   # } if !`git config --global github.user`.empty? && !`git config --global github.token`.empty?
     
     begin
       # If not env vars, then ~/.github/secrets.yml

--- a/lib/github-api-client/config.rb
+++ b/lib/github-api-client/config.rb
@@ -20,6 +20,11 @@ module GitHub
       "token" => ENV['GITHUB_TOKEN']
     } if ENV['GITHUB_USER'] && ENV['GITHUB_TOKEN']
     
+    Secrets = {
+      "login" => `git config --global github.user`.strip, 
+      "token" => `git config --global github.token`.strip
+    } if `git config --global github.user` && `git config --global github.token`
+    
     begin
       # If not env vars, then ~/.github/secrets.yml
       Secrets ||= YAML::load_file(GitHub::Config::Path[:secrets])['user']

--- a/lib/github-api-client/config.rb
+++ b/lib/github-api-client/config.rb
@@ -20,7 +20,7 @@ module GitHub
       "token" => ENV['GITHUB_TOKEN']
     } if ENV['GITHUB_USER'] && ENV['GITHUB_TOKEN']
     
-    Secrets = {
+    Secrets ||= {
       "login" => `git config --global github.user`.strip, 
       "token" => `git config --global github.token`.strip
     } if `git config --global github.user` && `git config --global github.token`

--- a/spec/github-api-client_spec.rb
+++ b/spec/github-api-client_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe "GitHub Api Client" do
 
    before(:all) do
-   
+      
       @real_github_user = `git config --global github.user`.strip
       @real_github_token = `git config --global github.token`.strip
 
@@ -19,13 +19,13 @@ describe "GitHub Api Client" do
       else
          `git config --global --unset github.user`
       end
-      
+
       if !@real_github_token.empty?
          `git config --global github.token "#{@real_github_token}"`
       else
          `git config --global --unset github.token`
       end
-      
+
    end
 
    context "configuration" do
@@ -44,12 +44,20 @@ describe "GitHub Api Client" do
 
       it "should find git config setting for github user if defined" do
          `git config --global github.user`.strip.should == 'test'
+         
       end
 
       it "should find git config setting for github token if defined" do
          `git config --global github.token`.strip.should == 'token'
+         
       end
 
+      it "should fall through if no user is defined" do
+         `git config --global --unset github.user`
+         GitHub::Config.reset
+         $stdout.expects(:puts)
+         load 'github-api-client/config.rb'
+      end
 
 
       context "options" do

--- a/spec/github-api-client_spec.rb
+++ b/spec/github-api-client_spec.rb
@@ -1,64 +1,100 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "GitHub Api Client" do
-  
-  context "configuration" do
-    
-    it "should create database on first run" do
-      File.stubs(:exists?).returns(false)
-      ActiveRecord::Migrator.expects(:migrate).with(GitHub::Config::Path[:migrations], nil).once
-      GitHub::Config.setup
-    end
-    
-    it "should not migrate database every time" do
-      File.stubs(:exists?).returns(true)
-      ActiveRecord::Migrator.expects(:migrate).never
-      GitHub::Config.setup
-    end
-    
-    context "options" do
-      
-      context "with enabled verbose" do
-        
-        it "should print messages" do
-          GitHub::Config::Options.expects(:"[]").with(:verbose).returns(true)
-          $stdout.expects(:puts).once
-          GitHub::Browser.get("/users/show/farnoy")
-        end
-        
+
+   before(:all) do
+   
+      @real_github_user = `git config --global github.user`.strip
+      @real_github_token = `git config --global github.token`.strip
+
+      `git config --global github.user "test"`
+      `git config --global github.token "token"`
+
+   end
+
+   after(:all) do
+
+      if !@real_github_user.empty?
+         `git config --global github.user "#{@real_github_user}"`
+      else
+         `git config --global --unset github.user`
       end
       
-      context "with disabled verbose" do
-        
-        it "should not print messages" do
-          GitHub::Config::Options.expects(:"[]").with(:verbose).returns(false)
-          $stdout.expects(:puts).never
-          GitHub::Browser.get("/users/show/farnoy")
-        end
-        
+      if !@real_github_token.empty?
+         `git config --global github.token "#{@real_github_token}"`
+      else
+         `git config --global --unset github.token`
       end
-                
-    end
-  end
-  
-  context "basics" do
-    
-    it "should save objects to database" do
-      u = GitHub::User.get("farnoy")
-      u.should == GitHub::User.find(u.id)
-    end
-    
-  end
-  
-  context "version" do
-    
-    it "should assign properly" do
-      GitHub::Config::Version.should == File.read('VERSION')
-    end
-    
-    it "should alias CAPITALIZED name for maniacs" do
-      GitHub::Config::Version.should == GitHub::Config::VERSION
-    end
-    
-  end
+      
+   end
+
+   context "configuration" do
+
+      it "should create database on first run" do
+         File.stubs(:exists?).returns(false)
+         ActiveRecord::Migrator.expects(:migrate).with(GitHub::Config::Path[:migrations], nil).once
+         GitHub::Config.setup
+      end
+
+      it "should not migrate database every time" do
+         File.stubs(:exists?).returns(true)
+         ActiveRecord::Migrator.expects(:migrate).never
+         GitHub::Config.setup
+      end
+
+      it "should find git config setting for github user if defined" do
+         `git config --global github.user`.strip.should == 'test'
+      end
+
+      it "should find git config setting for github token if defined" do
+         `git config --global github.token`.strip.should == 'token'
+      end
+
+
+
+      context "options" do
+
+         context "with enabled verbose" do
+
+            it "should print messages" do
+               GitHub::Config::Options.expects(:"[]").with(:verbose).returns(true)
+               $stdout.expects(:puts).once
+               GitHub::Browser.get("/users/show/farnoy")
+            end
+
+         end
+
+         context "with disabled verbose" do
+
+            it "should not print messages" do
+               GitHub::Config::Options.expects(:"[]").with(:verbose).returns(false)
+               $stdout.expects(:puts).never
+               GitHub::Browser.get("/users/show/farnoy")
+            end
+
+         end
+
+      end
+   end
+
+   context "basics" do
+
+      it "should save objects to database" do
+         u = GitHub::User.get("farnoy")
+         u.should == GitHub::User.find(u.id)
+      end
+
+   end
+
+   context "version" do
+
+      it "should assign properly" do
+         GitHub::Config::Version.should == File.read('VERSION')
+      end
+
+      it "should alias CAPITALIZED name for maniacs" do
+         GitHub::Config::Version.should == GitHub::Config::VERSION
+      end
+
+   end
 end

--- a/spec/github-api-client_spec.rb
+++ b/spec/github-api-client_spec.rb
@@ -3,12 +3,15 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe "GitHub Api Client" do
 
    before(:all) do
-      
+
       @real_github_user = `git config --global github.user`.strip
       @real_github_token = `git config --global github.token`.strip
 
-      `git config --global github.user "test"`
-      `git config --global github.token "token"`
+      `git config --global --unset github.user`
+      `git config --global --unset github.token`
+
+
+    
 
    end
 
@@ -43,13 +46,17 @@ describe "GitHub Api Client" do
       end
 
       it "should find git config setting for github user if defined" do
+         `git config --global github.user "test"`
          `git config --global github.user`.strip.should == 'test'
-         
+         `git config --global --unset github.user`
+
+
       end
 
       it "should find git config setting for github token if defined" do
+         `git config --global github.token "token"`
          `git config --global github.token`.strip.should == 'token'
-         
+         `git config --global --unset github.token`
       end
 
       it "should fall through if no user is defined" do


### PR DESCRIPTION
Currently there are options for getting them form secrets.yml or from environment variables. I thought it would be good to get them from git as it follows the Github tutorial on setting these from http://help.github.com/git-email-settings. 

Also, I thought adding the config message to the README might be a good idea. Wasn't sure what heading to put it under. 
