### PR TITLE
Rebustness and :fetch for user repos

### DIFF
--- a/lib/github-api-client/base.rb
+++ b/lib/github-api-client/base.rb
@@ -42,6 +42,7 @@ module GitHub
     # @param [Hash] attributes GitHub API retrieved attributes to be parsed
     # @return [Hash] parsed attributes, fully compatibile with local db
     def self.parse_attributes(resource, attributes)
+      return {} unless attributes # Guard against empty results
       hash = case resource
         when :user_get then {:public_repo_count => :nil, :public_gist_count => :nil, :created => :nil, :permission => :nil, :followers_count => :nil, :following_count => :nil}
         when :user_search then {:name => :login, :username => :login, :fullname => :name, :followers => :nil, :repos => :nil, :created => :nil, :permission => :nil}
@@ -49,6 +50,7 @@ module GitHub
         when :org_get then {:public_gist_count => nil, :public_repo_count => nil, :following_count => :nil, :followers_count => :nil}
         when :org_repo_index then {:owner => nil, :open_issues => nil, :has_issues => nil, :watchers => nil, :forks => nil, :fork => :b_fork, :gravatar_id => nil, :organization => :organization_login, :master_branch => nil}
         when :org_repo_get then {:owner => nil, :open_issues => nil, :has_issues => nil, :watchers => nil, :forks => nil, :fork => :b_fork, :gravatar_id => nil, :organization => :organization_login}
+        else raise "Unknown resource #{resource.inspect} with attributes #{attributes.inspect}"
       end
       # Provides abstraction layer between YAML :keys and 'keys' returned by Hub
       symbolized_resources = [:repo_get, :org_repo_index, :org_repo_get]

--- a/lib/github-api-client/config.rb
+++ b/lib/github-api-client/config.rb
@@ -15,22 +15,24 @@ module GitHub
     VERSION = Version
     
     # Secrets array, uses env vars if defined
-    Secrets = {
-      "login" => ENV['GITHUB_USER'], 
-      "token" => ENV['GITHUB_TOKEN']
-    } if ENV['GITHUB_USER'] && ENV['GITHUB_TOKEN']
-    
-    Secrets ||= {
-      "login" => `git config --global github.user`.strip, 
-      "token" => `git config --global github.token`.strip
-    } if `git config --global github.user` && !`git config --global github.token`
-   
-    begin
-      # If not env vars, then ~/.github/secrets.yml
-      Secrets ||= YAML::load_file(GitHub::Config::Path[:secrets])['user']
-    rescue Errno::ENOENT
-      # Eye candy with rainbow
-      puts <<-report
+    Secrets = case
+    when ENV['GITHUB_USER'] && ENV['GITHUB_TOKEN']
+      {
+        "login" => ENV['GITHUB_USER'], 
+        "token" => ENV['GITHUB_TOKEN']
+      }
+    when `git config --global github.user` && !`git config --global github.token`
+      {
+        "login" => `git config --global github.user`.strip, 
+        "token" => `git config --global github.token`.strip
+      } if `git config --global github.user` && !`git config --global github.token`
+    else
+      begin
+        # If not env vars, then ~/.github/secrets.yml
+        YAML::load_file(GitHub::Config::Path[:secrets])['user']
+      rescue Errno::ENOENT
+        # Eye candy with rainbow
+        puts <<-report
 You have three ways of defining your user to have authenticated access to your API:
   #{"1.".color(:cyan)} Put a file in: #{GitHub::Config::Path[:secrets].color(:blue).bright}
     Define in yaml:
@@ -39,11 +41,10 @@ You have three ways of defining your user to have authenticated access to your A
         #{"token".color(:blue).bright}: #{"your_token".color(:magenta)}
   #{"2.".color(:cyan)} Put #{"GITHUB_USER".color(:green).bright} and #{"GITHUB_TOKEN".color(:blue).bright} in your environment, so github-api-client can read it.
   #{"3.".color(:cyan)} Configure your global git profile as defined here #{"http://help.github.com/git-email-settings/".color(:blue).bright}
-  
+
       report
+      end
     end
-    
-    Secrets ||= nil
     
     Options = {
       :verbose => false

--- a/lib/github-api-client/organization.rb
+++ b/lib/github-api-client/organization.rb
@@ -30,7 +30,7 @@ module GitHub
     private
     def get_members
       members = YAML::load(GitHub::Browser.get "/organizations/#{login}/public_members")['users']
-      puts "Fetching members for #{"organization".color(:magenta).bright} #{self.login.color(:green).bright}"
+      puts "Fetching members for #{"organization".color(:magenta).bright} #{self.login.dup.color(:green).bright}"
       i, count = 0, members.count.to_s.color(:green).bright
       self.transaction do
         members.each do |user|
@@ -46,7 +46,7 @@ module GitHub
       
     def get_repositories
       repos = YAML::load(GitHub::Browser.get "/organizations/#{login}/public_repositories")['repositories']
-      puts "Fetching repositories for #{"organization".color(:magenta).bright} #{self.login.color(:green).bright}"
+      puts "Fetching repositories for #{"organization".color(:magenta).bright} #{self.login.dup.color(:green).bright}"
       i, count = 0, repos.count.to_s.color(:green).bright
       self.transaction do
         repos.each do |repo|

--- a/lib/github-api-client/repo.rb
+++ b/lib/github-api-client/repo.rb
@@ -47,7 +47,7 @@ module GitHub
     private
     def get_watchers
       watchers = YAML::load(GitHub::Browser.get("/repos/show/#{self.permalink}/watchers"))['watchers']
-      puts "Fetching watchers for #{"repo".color(:blue).bright} #{self.permalink.color(:green).bright}"
+      puts "Fetching watchers for #{"repo".color(:blue).bright} #{self.permalink.dup.color(:green).bright}"
       i, count = 0, watchers.count.to_s.color(:green).bright
       self.transaction do
         watchers.each do |watcher|


### PR DESCRIPTION
1) Changed definition of config Secrets so that the constant isn't re-defined, or referred to before being defined.
2) Added fetch(:repos) for user, to retrieve users's repositories.
3) Added some robustness of Base#parse_attributes.

Note, you're master branch is still referencing a nonexistent commit, which causes problems when cloning.
